### PR TITLE
Add skanlite to Release and Unstable

### DIFF
--- a/nci/release.yaml
+++ b/nci/release.yaml
@@ -157,6 +157,7 @@ anongit.neon.kde.org:
     - libkgapi
     - muon
     - skrooge
+    - skanlite
   - neon-packaging:
     - kphotoalbum
     - digikam

--- a/nci/unstable.yaml
+++ b/nci/unstable.yaml
@@ -177,6 +177,7 @@ anongit.neon.kde.org:
     - libkgapi
     - muon
     - skrooge
+    - skanlite
     - massif-visualizer
   - neon-packaging:
     - '*'


### PR DESCRIPTION
Add Skanlite for Neon, based on the existing kde-extras/skanlite repo.  Added the Neon/release and Neon/unstable branches. 

After this merge, it would be great to run the job to create the Jenkins jobs. 