### PR TITLE
Add kdevelop-python/php and also drop the override for gpgpme as we now have an official tarball

### DIFF
--- a/overrides/base.yaml
+++ b/overrides/base.yaml
@@ -94,6 +94,22 @@
     upstream_scm:
       branch: 5.0
 
+'*anongit.neon*/kde-std/kdevelop-python':
+  '*':
+    upstream_scm:
+      url: git://anongit.kde.org/kdev-python.git
+  '{Neon/stable,Neon/release}':
+    upstream_scm:
+      branch: 5.0
+
+'*anongit.neon*/kde-std/kdevelop-php':
+  '*':
+    upstream_scm:
+      url: git://anongit.kde.org/kdev-php.git
+  '{Neon/stable,Neon/release}':
+    upstream_scm:
+      branch: 5.0
+
 '*anongit.neon*/kde-std/sddm':
   '{Neon/mobile}':
     upstream_scm:

--- a/overrides/base.yaml
+++ b/overrides/base.yaml
@@ -209,12 +209,6 @@
       type: tarball
       url: http://sourceforge.mirrorservice.org/d/dr/drumstick/1.0.2/drumstick-1.0.2.tar.bz2
 
-'*anongit.neon*/forks/gpgme':
-  Neon/unstable:
-    upstream_scm:
-      type: tarball
-      url: http://weegie.edinburghlinux.co.uk/~tittiatcoke/gpgme-1.7.0~git20161013.tar.bz2
-
 '*{anonscm.debian,anongit.neon}*/frameworks/prison':
   'Neon/{release}':
     upstream_scm:


### PR DESCRIPTION
These two commits add the overrides required for kdevelop-python and kdevelop-php. (URL and branch). The second commit drops the special tarball for gpgme as that we now have an official 1.7.1 release on the normal location